### PR TITLE
Require SPOTIFY_TOKEN env, remove scraping, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ Now you can easily schedule this to run using `crontab`, just edit it with `cron
 
 which will execute it every 7 days so that you will never lose any songs in your Release Radar or Discover Weekly.
 
+# Token Usage
+
+**A Spotify access token is required.**
+
+To use this tool, you must set the `SPOTIFY_TOKEN` environment variable with your own Spotify Bearer token. The app will not function without it.
+
+How to extract your token:
+
+1. Open [Spotify Web Player](https://open.spotify.com/) in your browser and log in.
+2. Open Developer Tools (usually F12 or right-click → Inspect).
+3. Go to the Network tab.
+4. Play any song or interact with the page.
+5. Click on any XHR request in the list (e.g. `playlist`, `search`, etc).
+6. In the request headers, look for the `authorization` header. It will look like:
+   
+   ```
+   authorization: Bearer BQ...your_token_here...
+   ```
+7. Copy the entire token (everything after `Bearer `).
+8. Set it in your shell before running the app:
+
+```bash
+export SPOTIFY_TOKEN=your_token_here
+spotifydownload -playlist PLAYLIST_URL
+```
+
+If the token expires, repeat the steps above to get a new one.
+
 ## Contributing
 
 Pull requests are welcome. Feel free to...

--- a/getplaylist/getplaylist.go
+++ b/getplaylist/getplaylist.go
@@ -3,8 +3,8 @@ package getplaylist
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -187,34 +187,13 @@ func GetTracks(spotifyURL string) (playlistName string, tracks []Track, err erro
 }
 
 func getAccessToken(spotifyURL string) (accessToken string, err error) {
-	req, err := http.NewRequest("GET", spotifyURL, nil)
-	if err != nil {
-		log.Error(err)
+	// Require SPOTIFY_TOKEN env var
+	token := os.Getenv("SPOTIFY_TOKEN")
+	if token == "" {
+		err = fmt.Errorf("SPOTIFY_TOKEN environment variable is required. See README for instructions to extract your token from Spotify web player (Network tab, any XHR request, look for 'authorization' header)")
 		return
 	}
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:71.0) Gecko/20100101 Firefox/71.0")
-	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
-	req.Header.Set("Dnt", "1")
-	req.Header.Set("Connection", "keep-alive")
-	req.Header.Set("Cookie", "sp_ab=%7B%7D; sp_landing=http%3A%2F%2Fopen.spotify.com%2Fplaylist%2F37i9dQZF1EtsXGZhBtSWWl; sp_t=c695ff90921aafb17baa61ea6c01c2f8")
-	req.Header.Set("Upgrade-Insecure-Requests", "1")
-	req.Header.Set("Cache-Control", "max-age=0")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	defer resp.Body.Close()
-
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-	accessToken = getStringInBetween(string(bodyBytes), `"accessToken":"`, `"`)
-	log.Tracef("got access token: %s", accessToken)
-
-	if len(accessToken) < 3 {
-		err = fmt.Errorf("got no access token")
-	}
+	log.Tracef("using SPOTIFY_TOKEN from environment")
+	accessToken = token
 	return
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,10 @@ func init() {
 }
 
 func main() {
+	if os.Getenv("SPOTIFY_TOKEN") == "" {
+		fmt.Fprintln(os.Stderr, "Error: SPOTIFY_TOKEN environment variable is required. See README for instructions.")
+		os.Exit(1)
+	}
 	var playlistURL string
 	flag.StringVar(&playlistURL, "playlist", "", "The Spotify playlist URL link")
 	flag.BoolVar(&debug, "debug", false, "Debug mode")


### PR DESCRIPTION
- Require `SPOTIFY_TOKEN` env variable; exit immediately if not set.
- Removed all token scraping/fallback logic
- Updated README with clear, step-by-step token extraction instructions.

> [!NOTE]
> Spotify changed their web player.
> scraping tokens is no longer reliable manual extraction is now required
